### PR TITLE
fix(gen): add missing import for log package

### DIFF
--- a/slick/main.go
+++ b/slick/main.go
@@ -126,11 +126,13 @@ SLICK_SQL_DB_PORT=
 }
 
 func writeMainContents(mod string) []byte {
-	c := fmt.Sprintf(`
-package main
+	c := fmt.Sprintf(`package main
 
 import (
+	"log"
+
 	"github.com/anthdm/slick"
+
 	"%s/handler"
 )
 


### PR DESCRIPTION
## Summary 

The generated main file was missing an import for the "log" package and required manual fixing. This change makes slick's workflow a little more.. _slick_.