### PR TITLE
fix(run): app printing invalid listen address

### DIFF
--- a/slick.go
+++ b/slick.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"strings"
 
 	"github.com/a-h/templ"
 	"github.com/joho/godotenv"
@@ -115,13 +116,26 @@ func (s *Slick) Start() error {
 	if err := godotenv.Load(); err != nil {
 		return err
 	}
-	var port string
-	port = os.Getenv("SLICK_HTTP_LISTEN_ADDR")
-	if len(port) == 0 {
-		port = ":3000"
+
+	// Retrieve and sanitize listen address from env
+	listenAddr := os.Getenv("SLICK_HTTP_LISTEN_ADDR")
+	listenAddr = strings.TrimSpace(listenAddr)
+
+	// If listen address is not set, use default host and port
+	if listenAddr == "" {
+		listenAddr = ":3000"
 	}
-	fmt.Printf("slick app running http://localhost:%s\n", port)
-	return http.ListenAndServe(port, s.router)
+
+	// Print the URL where the app is running
+	browsableURL := listenAddr
+	if strings.HasPrefix(browsableURL, ":") {
+		browsableURL = "localhost" + browsableURL
+	}
+
+	fmt.Printf("slick app running at http://%s\n", browsableURL)
+
+	// Start the HTTP server
+	return http.ListenAndServe(listenAddr, s.router)
 }
 
 func (s *Slick) add(method, path string, h Handler, plugs ...Plug) {


### PR DESCRIPTION
## Summary

Prior to this change, when executing `slick run` on a newly generated, unmodified project, the app would print the address `http://localhost::3000` when run. Trying to quick-open this URL in the browser results in an error/empty page due to the redundant colon between host and port.

This change fixes that and the app now displays a browsable address when running.

**Note**: There's obviously room for more sanitization etc., but I did not want this change to exceed the intent of this app at this stage. For me, I just want to play around with slick, and these changes simply make the experience a little more smooth :) 

Thanks for publishing this! Cheers